### PR TITLE
Tips <img> closing syntax cleanup

### DIFF
--- a/html/tips/layernames.html
+++ b/html/tips/layernames.html
@@ -9,5 +9,5 @@
     To rename a layer, r-click its number in the layer selection tab, and
     enter its name! To clear, just submit an empty string at the prompt.
   </p>
-  <img src="images/tip-layername.png"/ style="width: 400px;">
+  <img src="images/tip-layername.png" style="width: 400px;"/>
 </div>

--- a/html/tips/printable.html
+++ b/html/tips/printable.html
@@ -6,5 +6,5 @@
     non-empty layers. You can remove them at will, and print out an easy
     reference sheet!
   </p>
-  <img src="images/tip-print.png"/ style="width: 500px;">
+  <img src="images/tip-print.png" style="width: 500px;"/>
 </div>

--- a/html/tips/rmbkeys.html
+++ b/html/tips/rmbkeys.html
@@ -14,5 +14,5 @@
     This also works for most keys you can bind in combos, key overrides, macros,
     and tap dance!
   </p>
-  <img src="images/tip-contextmenu.png"/ style="width: 300px;">
+  <img src="images/tip-contextmenu.png" style="width: 300px;"/>
 </div>

--- a/html/tips/serial.html
+++ b/html/tips/serial.html
@@ -6,5 +6,5 @@
     and select a key. When it's bound to a new key, the active key to select
     jumps to the next in its series.
   </p>
-  <img src="images/tip-serial.png"/ style="width: 60vw; height: 30vh;">
+  <img src="images/tip-serial.png" style="width: 60vw; height: 30vh;"/>
 </div>

--- a/html/tips/typebind.html
+++ b/html/tips/typebind.html
@@ -9,5 +9,5 @@
   <p>
     Bonus: works exceptionally well with Serial Assignment!
   </p>
-  <img src="images/tip-typebind.png"/ style="width: 300px;">
+  <img src="images/tip-typebind.png" style="width: 300px;"/>
 </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -1295,8 +1295,7 @@
   <p>
     Bonus: works exceptionally well with Serial Assignment!
   </p>
-  <img src="images/tip-typebind.png"
-        / style="width: 300px;">
+  <img src="images/tip-typebind.png" style="width: 300px;"/>
 </div>
 <div class="tip">
   <h3>Quick actions for keys</h3>
@@ -1314,7 +1313,7 @@
     This also works for most keys you can bind in combos, key overrides, macros,
     and tap dance!
   </p>
-  <img src="images/tip-contextmenu.png"/ style="width: 300px;">
+  <img src="images/tip-contextmenu.png" style="width: 300px;"/>
 </div>
 <div class="tip">
   <h3>Printing layer maps</h3>
@@ -1324,7 +1323,7 @@
     non-empty layers. You can remove them at will, and print out an easy
     reference sheet!
   </p>
-  <img src="images/tip-print.png"/ style="width: 500px;">
+  <img src="images/tip-print.png" style="width: 500px;"/>
 </div>
 <div class="tip">
   <h3>Layer names</h3>
@@ -1337,7 +1336,7 @@
     To rename a layer, r-click its number in the layer selection tab, and
     enter its name! To clear, just submit an empty string at the prompt.
   </p>
-  <img src="images/tip-layername.png"/ style="width: 400px;">
+  <img src="images/tip-layername.png" style="width: 400px;"/>
 </div>
 <div class="tip">
   <h3>Serial Assignment</h3>
@@ -1347,7 +1346,7 @@
     and select a key. When it's bound to a new key, the active key to select
     jumps to the next in its series.
   </p>
-  <img src="images/tip-serial.png"/ style="width: 60vw; height: 30vh;">
+  <img src="images/tip-serial.png" style="width: 60vw; height: 30vh;"/>
 </div>
 
     </div>


### PR DESCRIPTION
This moves the slash intended to close &lt;img&gt; elements inside the tips directory so that it can do its job properly.