### PR TITLE
Bump scrollbar size from 5-12px, in order to make them more catchable

### DIFF
--- a/pages/css/mainboard.css
+++ b/pages/css/mainboard.css
@@ -1,7 +1,7 @@
 /* boards.css, for rendering the different boards. */
 ::-webkit-scrollbar {
-    width: 5px;
-    height: 5px;
+    width: 12px;
+    height: 12px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
5px is pretty hard to reliably interact with (at least for me), so this PR gives a bit more space for people on smaller windows to be able to comfortably slide the mainboard layout, especially horizontally.