### PR TITLE
Refactor editable name handling

### DIFF
--- a/pages/js/misc.js
+++ b/pages/js/misc.js
@@ -9,24 +9,43 @@
 ////////////////////////////////////
 //
 //  Editable names - these are saved in KBINFO.cosmetic
+//  TODO: what is actually stored in browser storage and cosmetic
+//  TODO: is unprefixed. it's arguable that "name" is better reserved
+//  TODO: for that naked usage, but getEditableName is relied on under
+//  TODO: that name elsewhere, so until there is a greenlight for
+//  TODO: refactoring that, we'll use "barename" for the unprefixed
+//  TODO: version and keep the signature and behavior of getEditableName
+//  TODO: unchanged.
 //
 ////////////////////////////////////
-function getEditableName(type, index, def, skipidx) {
+function getEditableBareName(type, index, def) {
     const local = getSaved('names', {});
-    if (!(type in KBINFO.cosmetic)) {
-        return def;
-    }
-    let prefix = index + ': ';
-    if (skipidx) {
-        prefix = '';
-    }
-    if (KBINFO.cosmetic[type][index]) {
-        return prefix + KBINFO.cosmetic[type][index];
-    } else if (type in local && index in local[type]) {
-        return prefix + local[type][index];
-    } else {
-        return index;
-    }
+    const rv = KBINFO.cosmetic?.[type]?.[index]
+        ?? local?.[type]?.[index]
+        ?? def
+        ?? '' + index;
+    return rv;
+}
+
+////////////////////////////////////
+//
+//  Compose an unambiguous label for entities whose names can be changed by
+//  the user by prefixing the given index, unless the given name itself
+//  *is* that index, in which case we do not prefix.
+//
+////////////////////////////////////
+function buildEditableLabel(index, name) {
+    // IMPORTANT: == is used here instead of === because it is very likely
+    // that index is coming in as a number and name as a stringified version
+    // of it, so we want loose equality checking here.
+    const rv = name == index ? name : `${index}: ${name}`;
+    return rv;
+}
+
+function getEditableName(type, index, def, skipidx) {
+    const barename = getEditableBareName(type, index, def);
+    const rv = skipidx ? barename : buildEditableLabel(index, barename);
+    return rv;
 }
 
 // Names: for layers, macros, etc. Saved to kbinfo.
@@ -35,7 +54,7 @@ function makeEditableName(editable, type, index) {
     editable.dataset.editableType = type;
     editable.dataset.editableIndex = index;
 
-    let name = getEditableName(type, index, '' + index);
+    let name = getEditableName(type, index);
 
     const editableContent = EL(
         'div',
@@ -58,34 +77,51 @@ function makeEditableName(editable, type, index) {
 function onClickEditIcon(editIcon, type, index) {
     editIcon.onclick = (ev) => {
         const local = getSaved('names', {});
-        ev.preventDefault();
-        name = getEditableName(type, index);
-        const newname = prompt('New name for ' + type + ' ' + name);
-        if (newname !== null) {
-            if (newname !== '') {
+        ev.preventDefault()
+
+        // names are what is stored in kbi and browser storage.
+        // labels also include a prefix containing the item index.
+        // despite the function name, getEditableName returns what
+        // we call labels here.
+        const oldName = getEditableBareName(type, index);
+        const oldLabel = buildEditableLabel(index, oldName);
+        const newName = prompt('New name for ' + type + ' ' + oldLabel);
+
+        if (newName !== null && newName !== oldName) {
+            // here we know that the user did not cancel the name change dialog,
+            // and what was entered was not what was already present
+            if (newName !== '') {
                 if (!(type in KBINFO.cosmetic)) {
                     KBINFO.cosmetic[type] = {};
                 }
                 if (!(type in local)) {
                     local[type] = {};
                 }
-                KBINFO.cosmetic[type][index] = newname;
-                local[type][index] = newname;
-                const layerLabel = find(`#layer-label-${index}`);
-                if (layerLabel) {
-                    layerLabel.innerText = newname;
-                }
+                KBINFO.cosmetic[type][index] = newName;
+                local[type][index] = newName;
             } else {
                 delete KBINFO.cosmetic[type][index];
                 delete local[type][index];
             }
+            setSaved('names', local);
+
+            const labelEl = find(`#${type}-label-${index}`);
+            if (labelEl) {
+                // TODO: i was unable to locate where this code actually takes
+                // TODO: effect, so unsure whether it wants the index prefix or
+                // TODO: not. preserving existing behavior, which did not include
+                // TODO: the prefix.
+                labelEl.innerText = newName;
+            }
+
             KEYUI.refreshAllKeys();
+
+            const newLabel = buildEditableLabel(index, newName);
+            for (const editable of findAll(`[data-editable="${type}.${index}"]`)) {
+                editable.innerText = newLabel;
+            }
         }
-        name = getEditableName(type, index);
-        setSaved('names', local);
-        for (const editable of findAll(`[data-editable="${type}.${index}"]`)) {
-            editable.innerText = name;
-        }
+
         return false;
     };
 }


### PR DESCRIPTION
This separates the management of named objects from the prefixing by index that is often used to present them to the user, so that it's not necessary to hit storage twice to get unprefixed and prefixed names. Believed to fix #41. External callers of getEditableName() should not see any difference in behavior. Also eliminates a hardcoded dependence inside onClickEditIcon() that assumes it will only be called on layers, freeing this function up to be reused for other named entities such as macros.