### PR TITLE
Second attempt at tackling layer names

### DIFF
--- a/pages/js/kbui/mainboard.js
+++ b/pages/js/kbui/mainboard.js
@@ -321,11 +321,40 @@ addInitializer('connected', () => {
 
   ////////////////////////////////////
   //
+  //  Populates the layer list. This was originally inlined in the
+  //  initializer, but is separated here into a separate function so
+  //  that it can be called by updateAll, and reflect names loaded from
+  //  a .kbi file. Currently it captures layerSelection from its environment,
+  //  but that could be passed in or fetched independently using browserutils'
+  //  get(). replaceChildren should be safe to use on anything not named IE,
+  //  and cleaner and more performant than deleting existing children by hand.
+  //  It would also be possible to walk the DOM and simply replace the inner
+  //  text, but doing it this way allows us to simply call this either on
+  //  app startup or as part of a MAINBOARD.updateAll cycle without worrying
+  //  over whether anything was in there previously.
+  //
+  ////////////////////////////////////
+  function populateLayerList() {
+    const nextChildren = [...Array(KBINFO.layers).keys()].map(layerid => {
+      const layerSel = EL('div', {
+        'data-layerid': layerid,
+        class: 'layer-select selection',
+      });
+      makeEditableName(layerSel, 'layer', layerid);
+      return layerSel;
+    });
+
+    layerSelection.replaceChildren(...nextChildren);
+  }
+
+  ////////////////////////////////////
+  //
   //  Called when a file is uploaded or a device is connected after a file
   //  is uploaded. Mark and queue all changes.
   //
   ////////////////////////////////////
   MAINBOARD.updateAll = () => {
+    populateLayerList();
     drawLayer(MAINBOARD.selectedLayer);
 
     for (let ilayer = 0; ilayer < KBINFO.layers; ilayer++) {
@@ -430,18 +459,7 @@ addInitializer('connected', () => {
   // Draw the layer IDs and Names.
   //
   ////////////////////////////////////
-  children = [];
-  for (let i = 0; i < KBINFO.layers; i++) {
-    const layerid = i;
-    let layerName = getEditableName('layer', i, '' + i);
-    const layerSel = EL('div', {
-      'data-layerid': layerid,
-      class: 'layer-select selection',
-    });
-    makeEditableName(layerSel, 'layer', i);
-    children.push(layerSel);
-  }
-  appendChildren(layerSelection, ...children);
+  populateLayerList();
 
   function updateScrollButtons() {
     for (const scrollable of getAll('.horizontal-selection-container')) {

--- a/pages/js/misc.js
+++ b/pages/js/misc.js
@@ -9,24 +9,43 @@
 ////////////////////////////////////
 //
 //  Editable names - these are saved in KBINFO.cosmetic
+//  TODO: what is actually stored in browser storage and cosmetic
+//  TODO: is unprefixed. it's arguable that "name" is better reserved
+//  TODO: for that naked usage, but getEditableName is relied on under
+//  TODO: that name elsewhere, so until there is a greenlight for
+//  TODO: refactoring that, we'll use "barename" for the unprefixed
+//  TODO: version and keep the signature and behavior of getEditableName
+//  TODO: unchanged.
 //
 ////////////////////////////////////
-function getEditableName(type, index, def, skipidx) {
+function getEditableBareName(type, index, def) {
     const local = getSaved('names', {});
-    if (!(type in KBINFO.cosmetic)) {
-        return def;
-    }
-    let prefix = index + ': ';
-    if (skipidx) {
-        prefix = '';
-    }
-    if (KBINFO.cosmetic[type][index]) {
-        return prefix + KBINFO.cosmetic[type][index];
-    } else if (type in local && index in local[type]) {
-        return prefix + local[type][index];
-    } else {
-        return index;
-    }
+    const rv = KBINFO.cosmetic?.[type]?.[index]
+        ?? local?.[type]?.[index]
+        ?? def
+        ?? '' + index;
+    return rv;
+}
+
+////////////////////////////////////
+//
+//  Compose an unambiguous label for entities whose names can be changed by
+//  the user by prefixing the given index, unless the given name itself
+//  *is* that index, in which case we do not prefix.
+//
+////////////////////////////////////
+function buildEditableLabel(index, name) {
+    // IMPORTANT: == is used here instead of === because it is very likely
+    // that index is coming in as a number and name as a stringified version
+    // of it, so we want loose equality checking here.
+    const rv = name == index ? name : `${index}: ${name}`;
+    return rv;
+}
+
+function getEditableName(type, index, def, skipidx) {
+    const barename = getEditableBareName(type, index, def);
+    const rv = skipidx ? barename : buildEditableLabel(index, barename);
+    return rv;
 }
 
 // Names: for layers, macros, etc. Saved to kbinfo.
@@ -35,7 +54,7 @@ function makeEditableName(editable, type, index) {
     editable.dataset.editableType = type;
     editable.dataset.editableIndex = index;
 
-    let name = getEditableName(type, index, '' + index);
+    let name = getEditableName(type, index);
 
     const editableContent = EL(
         'div',
@@ -58,34 +77,51 @@ function makeEditableName(editable, type, index) {
 function onClickEditIcon(editIcon, type, index) {
     editIcon.onclick = (ev) => {
         const local = getSaved('names', {});
-        ev.preventDefault();
-        name = getEditableName(type, index);
-        const newname = prompt('New name for ' + type + ' ' + name);
-        if (newname !== null) {
-            if (newname !== '') {
+        ev.preventDefault()
+
+        // names are what is stored in kbi and browser storage.
+        // labels also include a prefix containing the item index.
+        // despite the function name, getEditableName returns what
+        // we call labels here.
+        const oldName = getEditableBareName(type, index);
+        const oldLabel = buildEditableLabel(index, oldName);
+        const newName = prompt('New name for ' + type + ' ' + oldLabel);
+
+        if (newName !== null && newName !== oldName) {
+            // here we know that the user did not cancel the name change dialog,
+            // and what was entered was not what was already present
+            if (newName !== '') {
                 if (!(type in KBINFO.cosmetic)) {
                     KBINFO.cosmetic[type] = {};
                 }
                 if (!(type in local)) {
                     local[type] = {};
                 }
-                KBINFO.cosmetic[type][index] = newname;
-                local[type][index] = newname;
-                const layerLabel = find(`#layer-label-${index}`);
-                if (layerLabel) {
-                    layerLabel.innerText = newname;
-                }
+                KBINFO.cosmetic[type][index] = newName;
+                local[type][index] = newName;
             } else {
                 delete KBINFO.cosmetic[type][index];
                 delete local[type][index];
             }
+            setSaved('names', local);
+
+            const labelEl = find(`#${type}-label-${index}`);
+            if (labelEl) {
+                // TODO: i was unable to locate where this code actually takes
+                // TODO: effect, so unsure whether it wants the index prefix or
+                // TODO: not. preserving existing behavior, which did not include
+                // TODO: the prefix.
+                labelEl.innerText = newName;
+            }
+
             KEYUI.refreshAllKeys();
+
+            const newLabel = buildEditableLabel(index, newName);
+            for (const editable of findAll(`[data-editable="${type}.${index}"]`)) {
+                editable.innerText = newLabel;
+            }
         }
-        name = getEditableName(type, index);
-        setSaved('names', local);
-        for (const editable of findAll(`[data-editable="${type}.${index}"]`)) {
-            editable.innerText = name;
-        }
+
         return false;
     };
 }


### PR DESCRIPTION
Addressing your comment from https://github.com/captdeaf/keybard/pull/39, I believe your 1-3 cases are handled properly by lower-level changes that make getEditableName (and anything that depends on it, such as makeEditableName) use potential sources in the desired order: KBINFO.cosmetics, browser storage, passed in default, and finally a stringified version of the index in the event that nothing else is available.

getEditableName should be able to be called from any state and return the best answer we have. There may still be a hole whereby browser storage is not directly updated on .kbi load, but I thought it might be worth having you take a look at this approach before addressing that and see if it is amenable to your taste.

This supersedes both https://github.com/captdeaf/keybard/pull/39 and https://github.com/captdeaf/keybard/pull/42.